### PR TITLE
Add the statement (北京大学学位论文原创性声明和使用授权说明)

### DIFF
--- a/Statement.tex
+++ b/Statement.tex
@@ -1,0 +1,63 @@
+\chapter*{北京大学学位论文原创性声明和使用授权说明}
+
+\begin{center}
+    \scalebox{1.5}{\textbf{原创性声明}}
+\end{center}
+
+\bigskip
+
+本人郑重声明：所呈交的学位论文，是本人在导师的指导下，独立进行研究工作所取得的成果。除文中已经注明引用的内容外，本论文不含任何其他个人或集体已经发表或撰写过的作品或成果。对本文的研究做出重要贡献的个人和集体，均已在文中以明确方式标明。本声明的法律结果由本人承担。
+
+\bigskip
+
+\begin{center}
+    论文作者签名： \qquad\qquad 日期：\qquad 年\quad 月\quad 日
+\end{center}
+
+\bigskip
+
+\begin{center}
+\scalebox{1.5}{\textbf{学位论文使用授权说明}}
+
+（必须装订在提交学校图书馆的印刷本）
+\end{center}
+
+\bigskip
+
+本人完全了解北京大学关于收集、保存、使用学位论文的规定，即：
+\begin{itemize}
+    \item 按照学校要求提交学位论文的印刷本和电子版本；
+    \item 学校有权保存学位论文的印刷本和电子版，并提供目录检索与阅览服务，在校园网上提供服务；
+    \item 学校可以采用影印、缩印、数字化或其它复制手段保存论文；
+    \item 因某种特殊原因需要延迟发布学位论文电子版，授权学校$\Box$一年/$\Box$两年/$\Box$三年以后，在校园网上全文发布。
+\end{itemize}{}
+
+\begin{center}
+（保密论文在解密后遵守此规定）
+\end{center}
+
+\bigskip
+
+\begin{center}
+论文作者签名： \qquad\qquad 导师签名：\qquad\qquad    
+
+日期：\qquad 年\quad 月\quad 日
+\end{center}
+
+
+\addcontentsline{toc}{chapter}{北京大学学位论文原创性声明和使用授权说明}
+\fancypagestyle{plain}
+{
+	\fancyhf{}
+	\fancyhead[RE,RO]{北京大学学位论文原创性声明和使用授权说明}
+	\fancyhead[LE,LO]{北京大学本科生毕业论文}
+	\fancyfoot[CO,CE]{~\thepage~}
+	\renewcommand{\headrulewidth}{0.7pt}
+	\renewcommand{\footrulewidth}{0pt}
+}
+\fancyhf{}
+\fancyhead[RE,RO]{北京大学学位论文原创性声明和使用授权说明}
+\fancyhead[LE,LO]{北京大学本科生毕业论文}
+\fancyfoot[CO,CE]{~\thepage~}
+\renewcommand{\headrulewidth}{0.7pt}
+\renewcommand{\footrulewidth}{0pt}


### PR DESCRIPTION
Although the template provided by EECS department does not include this statement, it is included in the template provided university. 
This pull request provides a tex file for this statement, in case someone needs it.
To include the tex file, just add `\inclue{Statement}` in `Template.tex`.

However, the title takes two rows because of the specified font size.